### PR TITLE
feat: add OBS livestream support

### DIFF
--- a/app/api/livestreams.ts
+++ b/app/api/livestreams.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { apiGet } from 'lib/api';
+import { apiGet, apiPost } from 'lib/api';
 import { getToken } from 'lib/getToken';
 
 export const getFeaturedLivestreams = async (limit: number, page: number = 1) => {
@@ -17,3 +17,25 @@ export const getFeaturedLivestreams = async (limit: number, page: number = 1) =>
     );
     return response;
 };
+
+// Create a new livestream and return streaming credentials (server and key)
+export const createLivestream = async (body: Record<string, any> = {}) => {
+    const token = await getToken();
+
+    // The backend returns the ingest server and stream key which can be
+    // used with OBS.  No payload is required for the default behaviour so
+    // we send an empty object if none is provided.
+    const response = await apiPost<ICreateLivestreamCredentials>(
+        `livestreams/create`,
+        body,
+        token
+    );
+
+    return response;
+};
+
+export interface ICreateLivestreamCredentials {
+    server: string;
+    stream_key: string;
+    stream_url?: string;
+}

--- a/components/Dashboard/LiveStream/LiveStreamAddInfo.tsx
+++ b/components/Dashboard/LiveStream/LiveStreamAddInfo.tsx
@@ -14,6 +14,7 @@ import {
 } from "components/ui/select";
 import { Switch } from "components/ui/switch";
 import { useState } from "react";
+import { createLivestream } from "api/livestreams";
 import { FaArrowLeft, FaVideo } from "react-icons/fa";
 import { IoIosArrowDown, IoIosArrowForward } from "react-icons/io";
 import { MdCancel } from "react-icons/md";
@@ -30,13 +31,30 @@ const LiveStreamAddInfo = () => {
   });
   const [selectedCohost, setSelectedCohost] = useState<string[] | null>(["John"]);
   const [searchValue, setSearchValue] = useState("");
+  const [obsStreamSource, setObsStreamSource] = useState(false);
+  const [server, setServer] = useState("");
+  const [streamKey, setStreamKey] = useState("");
   let questionSent = false;
   let showQuestionAndAnswer = true;
   let notInvited = false;
 
-  let OBSStreamSource = true;
-
   let sendingGift = false;
+
+  const handleStreamSourceChange = async (value: string) => {
+    const isObs = value === "hp_camera" || value === "obs";
+    setObsStreamSource(isObs);
+
+    if (isObs) {
+      const res = await createLivestream({});
+      if (res?.status && res.data) {
+        setServer(res.data.server || res.data.stream_url || "");
+        setStreamKey(res.data.stream_key);
+      }
+    } else {
+      setServer("");
+      setStreamKey("");
+    }
+  };
 
   const getTitle = () => {
     if (liveStreamInfo.addingLiveStreamInfo || liveStreamInfo.addingLiveStreamCamera)
@@ -187,7 +205,7 @@ const LiveStreamAddInfo = () => {
               <Label htmlFor="category" className="font-semibold">
                 Stream Source
               </Label>
-              <Select>
+              <Select onValueChange={handleStreamSourceChange}>
                 <SelectTrigger className="w-full !border-none !outline-none bg-accent !ring-0">
                   <SelectValue placeholder="Select" />
                 </SelectTrigger>
@@ -201,13 +219,18 @@ const LiveStreamAddInfo = () => {
                 </SelectContent>
               </Select>
             </div>
-            {OBSStreamSource && (
+            {obsStreamSource && (
               <>
                 <div className="flex flex-col gap-y-2">
                   <Label htmlFor="concern" className="font-semibold ">
                     Server
                   </Label>
-                  <Input className="bg-accent no_input_border" placeholder="Server" />
+                  <Input
+                    className="bg-accent no_input_border"
+                    placeholder="Server"
+                    value={server}
+                    readOnly
+                  />
                 </div>
                 <div className="flex flex-col gap-y-2">
                   <Label htmlFor="concern" className="font-semibold ">
@@ -216,6 +239,8 @@ const LiveStreamAddInfo = () => {
                   <Input
                     className="bg-accent no_input_border"
                     placeholder="Stream Source Key"
+                    value={streamKey}
+                    readOnly
                   />
                 </div>
               </>


### PR DESCRIPTION
## Summary
- add server action to create livestream and return OBS credentials
- allow Go Live form to fetch and display OBS stream server and key

## Testing
- `bun test`
- `bun run lint` *(fails: recommends adding Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68c579581b78832e9490c2d95108b4f6