### PR TITLE
Fix Google social login payload for backend auth

### DIFF
--- a/app/api/auth/authOptions.ts
+++ b/app/api/auth/authOptions.ts
@@ -112,14 +112,26 @@ export const authOptions: NextAuthOptions = {
         try {
           // console.log(`[GoogleSignIn] Attempting to register/login with backend at ${API_BASE_URL}/auth/social-account`);
 
+          const providerId =
+            account.providerAccountId ||
+            (typeof (profile as any)?.sub === "string" ? (profile as any).sub : "");
+
+          const providerToken = account.id_token || account.access_token;
+
+          if (!providerToken || !providerId) {
+            return false;
+          }
+
           const payload = {
             audience: "web",
             auth_type: "google",
+            registration_type: "google",
             device: "browser",
             device_id: null,
             fcm_token: null,
             provider: "google",
-            provider_token: account.id_token || account.access_token,
+            provider_id: providerId,
+            provider_token: providerToken,
             timezone: getTimeZone(),
           };
 


### PR DESCRIPTION
### Motivation
- Google sign-ins appeared to complete in the UI but failed at the backend with an authentication error because the social-auth payload was missing or mis-formed fields the backend expects.
- The backend requires a `provider_id` and a provider token and also expects the registration type to be present for social registrations.

### Description
- Derive `providerId` from `account.providerAccountId` with a fallback to the Google profile `sub` and expose it as `provider_id` in the payload.
- Consolidate the provider token into `providerToken` from `account.id_token` or `account.access_token` and include it as `provider_token` in the payload.
- Add a guard to return `false` early if either `providerToken` or `providerId` is missing to avoid calling the backend with an invalid payload.
- Add `registration_type: "google"` to the `/auth/social-account` request body so the backend receives the expected registration metadata. (File: `app/api/auth/authOptions.ts`)

### Testing
- Ran `npm run lint`, but the command could not complete non-interactively because `next lint` triggered the initial ESLint configuration prompt in this environment, so linting could not be validated automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cb9928684832e947a41847d1e5d99)