### PR TITLE
Fix Google sign-in token payload and OAuth redirect flow

### DIFF
--- a/app/api/auth/authOptions.ts
+++ b/app/api/auth/authOptions.ts
@@ -119,10 +119,18 @@ export const authOptions: NextAuthOptions = {
             device_id: null,
             fcm_token: null,
             provider: "google",
+            provider_id: (profile as any)?.sub ?? null,
+            email: (profile as any)?.email ?? null,
+            name: (profile as any)?.name ?? null,
             provider_token: account.id_token || account.access_token,
+            access_token: account.access_token ?? null,
+            id_token: account.id_token ?? null,
             timezone: getTimeZone(),
           };
 
+          if (!payload.provider_token) {
+            return false;
+          }
 
           const res = await fetch(`${API_BASE_URL}/auth/social-account`, {
             method: "POST",

--- a/components/Auth/Login.tsx
+++ b/components/Auth/Login.tsx
@@ -136,14 +136,9 @@ export function Login({ className, ...props }: LoginProps) {
     try {
       setIsGoogleLoading(true);
 
-      const result = await signIn("google", {
-        callbackUrl: "/home", 
-        redirect: false,
+      await signIn("google", {
+        callbackUrl: "/home",
       });
-
-      if (result?.error) {
-        toast.error(result.error);
-      }
     } catch (error) {
       console.error("Google sign-in error:", error);
       toast.error("Failed to sign in with Google. Please try again.");

--- a/components/Auth/Register.tsx
+++ b/components/Auth/Register.tsx
@@ -184,14 +184,9 @@ export function Register({ className, ...props }: RegisterProps) {
     try {
       setIsGoogleAuthLoading(true);
   
-      const result = await signIn("google", {
-        callbackUrl: "/home", 
-        redirect: false,
+      await signIn("google", {
+        callbackUrl: "/home",
       });
-  
-      if (result?.error) {
-        toast.error(result.error);
-      }
     } catch (error) {
       console.error("Google sign-in error:", error);
       toast.error("Failed to sign in with Google. Please try again.");


### PR DESCRIPTION
### Motivation

- Google sign-ins were landing on the generic auth error page after the provider returned successfully because the backend social-login endpoint was not consistently receiving the expected identity and token fields. 
- Client-side handling used `redirect: false` which produced a partial/fragile OAuth flow that could leave the app in an inconsistent state after provider callbacks. 

### Description

- Updated the NextAuth `signIn` callback in `app/api/auth/authOptions.ts` to include `provider_id` (`profile.sub`), `email`, `name`, and explicit token fields (`provider_token`, `access_token`, `id_token`) when posting to the backend `/auth/social-account`. 
- Added a defensive guard in the `signIn` callback to abort early and return `false` when no Google provider token is available. 
- Changed Google sign-in triggers in `components/Auth/Login.tsx` and `components/Auth/Register.tsx` to use the standard redirect-based OAuth flow (removed `redirect: false`) by calling `signIn("google", { callbackUrl: "/home" })` and awaiting the call. 

### Testing

- Ran TypeScript checks with `npx tsc --noEmit`, which completed successfully. 
- Attempted to run `npm run lint` but it could not complete non-interactively because Next.js prompted for initial ESLint setup in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cc03124cc832e9e023d076344288a)