### PR TITLE
Treat empty NEXTAUTH_URL as unset to prevent Invalid URL at build

### DIFF
--- a/lib/authConfig.ts
+++ b/lib/authConfig.ts
@@ -12,9 +12,13 @@ export const getAuthSecret = () => {
 
 export const getAuthUrl = () => {
   const vercelUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null;
-  const resolvedUrl = process.env.NEXTAUTH_URL ?? vercelUrl ?? "http://localhost:3000";
+  const envAuthUrl = process.env.NEXTAUTH_URL?.trim();
+  const resolvedUrl =
+    envAuthUrl && envAuthUrl.length > 0
+      ? envAuthUrl
+      : vercelUrl ?? "http://localhost:3000";
 
-  if (!process.env.NEXTAUTH_URL) {
+  if (!envAuthUrl) {
     process.env.NEXTAUTH_URL = resolvedUrl;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent an invalid/empty `NEXTAUTH_URL` environment value from being used during build-time server code which could produce `Invalid URL` errors during prerendering.

### Description
- Updated `lib/authConfig.ts` so `NEXTAUTH_URL` is trimmed and treated as unset when empty or whitespace-only and the resolved URL now falls back to `VERCEL_URL` or `http://localhost:3000` before being written to `process.env.NEXTAUTH_URL`.

### Testing
- Ran `npm run build`; the original `Invalid URL` source related to `NEXTAUTH_URL` resolution is addressed, but the build in this environment still fails due to `next/font` Google Fonts fetch errors (network/font fetch), so full production build verification is blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cc89703ac832e93a6445d751f3fa1)